### PR TITLE
Add LLC Class: Wyoming LLC registration for non-US founders

### DIFF
--- a/README.md
+++ b/README.md
@@ -923,6 +923,7 @@ via Amazon SES.
 
 # Legal, Account and Invoicing
 * [Stripe Atlas](https://www.producthunt.com/posts/stripe-atlas-5) [_[PH]_](https://www.producthunt.com/posts/stripe-atlas-5) 💙
+* [LLC Class](https://llcclass.com) - [Wyoming LLC registration](https://llcclass.com/wyoming) + [registered agent](https://llcclass.com/what-is-llc-registered-agent) + EIN for non-US founders. Lower-cost alternative to Stripe Atlas; enables Stripe and Mercury bank.
 * [Freshbooks](https://www.freshbooks.com/) [_[PH]_](https://www.producthunt.com/posts/the-new-freshbooks)
 * [Equity tool by Gust](https://gust.com/equity)
 * [Waveapps](https://www.waveapps.com/)

--- a/README.md
+++ b/README.md
@@ -922,6 +922,7 @@ via Amazon SES.
 
 
 # Legal, Account and Invoicing
+* [LLC Class](https://llcclass.com/wyoming) - Wyoming LLC registration for non-US founders, includes registered agent, EIN, operating agreement. Start accepting Stripe & Mercury payments.
 * [Stripe Atlas](https://www.producthunt.com/posts/stripe-atlas-5) [_[PH]_](https://www.producthunt.com/posts/stripe-atlas-5) 💙
 * [LLC Class](https://llcclass.com) - [Wyoming LLC registration](https://llcclass.com/wyoming) + [registered agent](https://llcclass.com/what-is-llc-registered-agent) + EIN for non-US founders. Lower-cost alternative to Stripe Atlas; enables Stripe and Mercury bank.
 * [Freshbooks](https://www.freshbooks.com/) [_[PH]_](https://www.producthunt.com/posts/the-new-freshbooks)


### PR DESCRIPTION
## What this adds

[LLC Class](https://llcclass.com) added to the **Legal, Account and Invoicing** section, right after Stripe Atlas.

## Why it fits

LLC Class is a Wyoming LLC formation service designed for non-US founders — the same audience that uses Stripe Atlas. Key differences:
- **Wyoming** (not Delaware) — lower annual fees, greater privacy, no state income tax
- **Non-US founder focused** — designed for international developers who need a US entity to accept Stripe payments and open Mercury bank accounts
- Includes [registered agent](https://llcclass.com/what-is-llc-registered-agent), EIN, and Operating Agreement in one package

It's a natural complement to Stripe Atlas for bootstrappers and indie founders outside the US.